### PR TITLE
소셜로그인 연동, 사용자 정보 조회 API 연동 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import MyPage from "./pages/mypage/MyPage";
 import MyPageCalendar from "./pages/mypage/MyPageCalendar";
 import MyPageReview from "./pages/mypage/MyPageReview";
 import MemberPage from "./pages/mypage/MemberPage";
+import OAuthCallback from "./pages/OauthCallback";
 
 const DefaultLayout = () => {
   return (
@@ -42,6 +43,10 @@ const App = () => {
       <Router>
         <Routes>
           <Route path="/login" element={<Login />} />
+          <Route
+            path="/oauth2/callback/:provider"
+            element={<OAuthCallback />}
+          />
 
           <Route element={<DefaultLayout />}>
             <Route path="/" element={<Main />} />

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from "../utils/apiConfig";
+import { OAuthResponse } from "../types/api/auth";
+
+export const handleOAuthLogin = async (
+  provider: string,
+  code: string
+): Promise<OAuthResponse> => {
+  const response = await axiosInstance.get(
+    `${process.env.REACT_APP_API_BASE_URL}/oauth2/callback/${provider}?code=${code}`
+  );
+
+  return response.data;
+};

--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,0 +1,12 @@
+import { axiosInstance } from "../utils/apiConfig";
+import { MemberInfo } from "../types/api/member";
+
+export const getMemberInfo = async (): Promise<MemberInfo> => {
+  const response = await axiosInstance.get(
+    `${process.env.REACT_APP_API_BASE_URL}/members/info`
+  );
+
+  console.log(response);
+
+  return response.data.data;
+};

--- a/src/components/MemberInfo.tsx
+++ b/src/components/MemberInfo.tsx
@@ -1,18 +1,9 @@
 import styled from "styled-components";
-
-interface MemberInfoProps {
-  isLoggedIn: boolean;
-  userInfo: {
-    name: string;
-    imageUrl: string;
-  } | null;
-  onLogin: () => void;
-  onLogout: () => void;
-}
+import { MemberInfoProps } from "../types/components/member";
 
 const MemberInfo = ({
   isLoggedIn,
-  userInfo,
+  memberInfo,
   onLogin,
   onLogout,
 }: MemberInfoProps) => {
@@ -20,8 +11,12 @@ const MemberInfo = ({
     <Container>
       {isLoggedIn ? (
         <>
-          <MemberImg src={userInfo?.imageUrl}></MemberImg>
-          <MemberName>{userInfo?.name}님</MemberName>
+          {memberInfo && (
+            <>
+              <MemberImg src={memberInfo.imageUrl} alt={memberInfo.name} />
+              <MemberName>{memberInfo.name}님</MemberName>
+            </>
+          )}
           <Button onClick={onLogout}>로그아웃</Button>
         </>
       ) : (
@@ -65,7 +60,7 @@ const Button = styled.button`
   color: white;
   border: none;
   border-radius: 4px;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 0.5rem;
   cursor: pointer;
 
   &:hover {

--- a/src/components/sidebar/SocialLoginButton.tsx
+++ b/src/components/sidebar/SocialLoginButton.tsx
@@ -1,36 +1,24 @@
-import React from "react";
 import styled from "styled-components";
-
-interface SocialLoginButtonProps {
-  iconSrc: React.ReactNode;
-  backgroundColor: string;
-  border: string;
-  text: string;
-  socialType: "kakao" | "google";
-}
+import { SocialLoginButtonProps } from "../../types/components/socialLoginButton";
 
 const SocialLoginButton = ({
-  socialType,
+  provider,
   iconSrc,
   backgroundColor,
   border,
   text,
 }: SocialLoginButtonProps) => {
-  const handleKakaoLogin = () => {
-    // 로그인 로직
-  };
-
-  const handleGoogleLogin = () => {
-    // 로그인 로직
+  const handleLogin = () => {
+    window.location.href = `${process.env.REACT_APP_API_BASE_URL}/oauth2/login?provider=${provider}`;
   };
 
   return (
     <Button
       backgroundColor={backgroundColor}
       border={border}
-      onClick={socialType === "kakao" ? handleKakaoLogin : handleGoogleLogin}
+      onClick={handleLogin}
     >
-      <IconWrapper socialType={socialType === "kakao"}>{iconSrc}</IconWrapper>
+      <IconWrapper provider={provider === "kakao"}>{iconSrc}</IconWrapper>
       <Text>{text}</Text>
     </Button>
   );
@@ -56,19 +44,19 @@ const Button = styled.button<{ backgroundColor: string; border: string }>`
   }
 `;
 
-const IconWrapper = styled.div<{ socialType: boolean }>`
+const IconWrapper = styled.div<{ provider: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-right: ${({ socialType }) => (socialType ? "0" : "1rem")};
+  margin-right: ${({ provider }) => (provider ? "0" : "1rem")};
 
   svg {
-    width: ${({ socialType, theme }) =>
-      socialType
+    width: ${({ provider, theme }) =>
+      provider
         ? theme.icon.loginKakaoIconWidth
         : theme.icon.loginGoogleIconWidth};
-    height: ${({ socialType, theme }) =>
-      socialType
+    height: ${({ provider, theme }) =>
+      provider
         ? theme.icon.loginKakaoIconHeight
         : theme.icon.loginGoogleIconHeight};
   }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -13,14 +13,14 @@ const Login = () => {
       <Content>
         <StyledLogo />
         <SocialLoginButton
-          socialType="kakao"
+          provider="kakao"
           iconSrc={<KakaoSVG />}
           backgroundColor="#FEE500"
           border="#FEE500"
           text="카카오 로그인"
         />
         <SocialLoginButton
-          socialType="google"
+          provider="google"
           iconSrc={<GoogleSVG />}
           backgroundColor="#FFFFFF"
           border="#E0E0E0"

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,21 +1,23 @@
-import React, { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import useKakaoMap from "../hooks/useKakaoMap";
 import LocationDetailModal from "../components/modals/LocationDetailModal";
 import locations from "../data/locations.json";
 import styled from "styled-components";
 import MemberInfo from "../components/MemberInfo";
+import { useAuthStore } from "../stores/useAuthStore";
 
 const Main = () => {
+  const navigate = useNavigate();
   const [selectedLocation, setSelectedLocation] = useState<any>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [memberInfo, setMemberInfo] = useState<{
-    name: string;
-    imageUrl: string;
-  } | null>(null);
+  const { isLoggedIn, memberInfo, fetchMemberInfo, logout } = useAuthStore();
 
-  const navigate = useNavigate();
+  useEffect(() => {
+    if (isLoggedIn) {
+      fetchMemberInfo();
+    }
+  }, [isLoggedIn]);
 
   const handleMarkerClick = (location: any) => {
     setSelectedLocation(location);
@@ -26,9 +28,8 @@ const Main = () => {
     navigate("/login");
   };
 
-  const handleLogout = () => {
-    setIsLoggedIn(false);
-    setMemberInfo(null);
+  const handleLogout = async () => {
+    await logout();
   };
 
   useKakaoMap("map", locations, handleMarkerClick);
@@ -47,7 +48,7 @@ const Main = () => {
 
       <MemberInfo
         isLoggedIn={isLoggedIn}
-        userInfo={memberInfo}
+        memberInfo={memberInfo}
         onLogin={handleLogin}
         onLogout={handleLogout}
       />

--- a/src/pages/OauthCallback.tsx
+++ b/src/pages/OauthCallback.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from "react";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
+import { handleOAuthLogin } from "../api/auth";
+import { useAuthStore } from "../stores/useAuthStore";
+import styled, { keyframes } from "styled-components";
+
+const OAuthCallback = () => {
+  const { provider } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { login } = useAuthStore();
+
+  useEffect(() => {
+    const query = new URLSearchParams(location.search);
+    const code = query.get("code");
+
+    const processOAuthCallback = async () => {
+      if (!provider || !code) return;
+      try {
+        const data = await handleOAuthLogin(provider, code);
+
+        await login({
+          accessToken: data.accessToken,
+        });
+
+        navigate("/");
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    processOAuthCallback();
+  }, [provider, location, navigate, login]);
+
+  return (
+    <Container>
+      <SpinnerWrapper>
+        <Spinner provider={provider} />
+      </SpinnerWrapper>
+      <Message>
+        로그인 처리 중입니다...
+        <br />
+        잠시만 기다려주세요.
+      </Message>
+    </Container>
+  );
+};
+
+export default OAuthCallback;
+
+const Container = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: #f9fafb;
+`;
+
+const spin = keyframes`
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+`;
+
+const SpinnerWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 2rem;
+`;
+
+const Spinner = styled.div<{ provider?: string }>`
+  border: 6px solid #e5e7eb;
+  border-top: 6px solid
+    ${({ provider }) => (provider === "kakao" ? "#ffcd00" : "#4285F4")};
+  border-radius: 50%;
+  width: 56px;
+  height: 56px;
+  animation: ${spin} 1s linear infinite;
+`;
+
+const Message = styled.div`
+  font-size: 1.25rem;
+  color: #374151;
+  text-align: center;
+  line-height: 1.6;
+  font-weight: 500;
+`;

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+import { getMemberInfo } from "../api/member";
+import { AuthState, LoginTokens } from "../types/stores/auth";
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isLoggedIn: !!localStorage.getItem("accessToken"),
+  memberInfo: null,
+
+  fetchMemberInfo: async () => {
+    try {
+      const memberInfo = await getMemberInfo();
+      set({ memberInfo });
+    } catch (error) {
+      console.log("유저 정보를 가져오는데 실패했습니다.");
+      set({ isLoggedIn: false, memberInfo: null });
+    }
+  },
+
+  login: async ({ accessToken }: LoginTokens) => {
+    localStorage.setItem("accessToken", accessToken);
+    set({ isLoggedIn: true });
+
+    const memberInfo = await getMemberInfo();
+    set({ memberInfo });
+  },
+
+  logout: async () => {
+    localStorage.removeItem("accessToken");
+    set({ isLoggedIn: false, memberInfo: null });
+  },
+}));

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -1,0 +1,3 @@
+export interface OAuthResponse {
+  accessToken: string;
+}

--- a/src/types/api/member.ts
+++ b/src/types/api/member.ts
@@ -1,0 +1,7 @@
+export interface MemberInfo {
+  id: number;
+  email: string;
+  name: string;
+  nickname: string;
+  imageUrl: string;
+}

--- a/src/types/components/member.ts
+++ b/src/types/components/member.ts
@@ -1,0 +1,8 @@
+import { MemberInfo } from "../api/member";
+
+export interface MemberInfoProps {
+  isLoggedIn: boolean;
+  memberInfo: MemberInfo | null;
+  onLogin: () => void;
+  onLogout: () => void;
+}

--- a/src/types/components/socialLoginButton.ts
+++ b/src/types/components/socialLoginButton.ts
@@ -1,0 +1,9 @@
+import { ReactNode } from "react";
+
+export interface SocialLoginButtonProps {
+  iconSrc: ReactNode;
+  backgroundColor: string;
+  border: string;
+  text: string;
+  provider: "kakao" | "google";
+}

--- a/src/types/stores/auth.ts
+++ b/src/types/stores/auth.ts
@@ -1,0 +1,13 @@
+import { MemberInfo } from "../api/member";
+
+export interface AuthState {
+  isLoggedIn: boolean;
+  memberInfo: MemberInfo | null;
+  login: (tokens: LoginTokens) => Promise<void>;
+  logout: () => Promise<void>;
+  fetchMemberInfo: () => Promise<void>;
+}
+
+export interface LoginTokens {
+  accessToken: string;
+}

--- a/src/utils/apiConfig.tsx
+++ b/src/utils/apiConfig.tsx
@@ -1,0 +1,44 @@
+import axios from "axios";
+
+export const apiBaseUrl = process.env.REACT_APP_API_BASE_URL;
+
+export const axiosInstance = axios.create({
+  baseURL: apiBaseUrl,
+  withCredentials: true,
+});
+
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const accessToken = localStorage.getItem("accessToken");
+
+    if (accessToken) {
+      config.headers["Authorization"] = `Bearer ${accessToken}`;
+    }
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+axiosInstance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    if (error.response.status === 401) {
+      try {
+        return axiosInstance(error.config);
+      } catch (refreshError) {
+        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+
+        localStorage.clear();
+
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);


### PR DESCRIPTION
## #️⃣연관된 이슈

#26 

## 📝작업 내용

소셜로그인(카카오, 구글)을 연동하고
로그인 후 반환하는 토큰으로 사용자 정보를 조회해 메인 페이지에 적용하고, Zustend를 사용하여 전역 상태로 관리합니다.
사용자 정보는 메이페이지 뿐만아니라 다양한 페이지에서 사용될 예정입니다.